### PR TITLE
Improve CI process

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - '**'
+    # ignore pushes to main as all changes go via a pull request
+    branches-ignore:
+      - main
     paths-ignore:
+      - '.vscode/settings.json'
       - '.editorconfig'
       - 'CONTRIBUTING.md'
       - 'README.md'
@@ -37,22 +41,23 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-        include-prerelease: true
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+          include-prerelease: true
 
-    - name: dotnet restore
-      run: dotnet restore
+      - name : dotnet restore
+        run: dotnet restore
 
-    - name: dotnet build
-      run: dotnet build --configuration ${{ env.PROJECT_CONFIGURATION }} --no-restore
+      - name: dotnet build
+        run: dotnet build --configuration ${{ env.PROJECT_CONFIGURATION }} --no-restore
 
-    - name: dotnet test
-      run: dotnet test --no-restore --verbosity minimal
+      - name: dotnet test
+        run: dotnet test --no-restore --verbosity minimal
 
-    - name: dotnet pack
-      run: dotnet pack --no-build --configuration ${{ env.PROJECT_CONFIGURATION }}
+      - name: dotnet pack
+        if: github.ref_name == 'main'
+        run: dotnet pack --no-build --configuration ${{ env.PROJECT_CONFIGURATION }}


### PR DESCRIPTION
- We do a PR build to main, there's no point in then running a push build straight after.
- Only dry run pack in the main PR