### PR TITLE
Don't need to include Microsoft.CodeAnalysis.NetAnalyzers for SDK pro…

### DIFF
--- a/src/PhoneNumbers/CountryInfo.cs
+++ b/src/PhoneNumbers/CountryInfo.cs
@@ -98,7 +98,7 @@ public sealed partial class CountryInfo
     /// </summary>
     /// <exception cref="FormatException">Thrown if the format string is not valid.</exception>
     /// <returns>The <see cref="PhoneNumberFormatter"/>.</returns>
-    internal PhoneNumberFormatter GetFormatter(string format) =>
+    internal static PhoneNumberFormatter GetFormatter(string format) =>
         s_formatters.SingleOrDefault(x => x.CanFormat(format)) ?? throw new FormatException($"{format} is not a supported format");
 
     /// <summary>

--- a/src/PhoneNumbers/PhoneNumber.cs
+++ b/src/PhoneNumbers/PhoneNumber.cs
@@ -267,5 +267,5 @@ public abstract class PhoneNumber
     /// <exception cref="FormatException">Thrown if the format string is not valid.</exception>
     /// <returns>The string representation of the value of this instance as specified by the format.</returns>
     public string ToString(string format) =>
-        Country.GetFormatter(format).Format(this);
+        CountryInfo.GetFormatter(format).Format(this);
 }

--- a/src/PhoneNumbers/PhoneNumbers.csproj
+++ b/src/PhoneNumbers/PhoneNumbers.csproj
@@ -37,10 +37,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.53.0.62665">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/PhoneNumbers.Tests/CountryInfo_Tests.cs
+++ b/test/PhoneNumbers.Tests/CountryInfo_Tests.cs
@@ -6,19 +6,23 @@ public class CountryInfo_Tests
 {
     [Fact]
     public void GetFormatter_E123_Returns_E123PhoneNumberFormatter() =>
-        Assert.IsType<E123PhoneNumberFormatter>(TestHelper.CreateCountryInfo().GetFormatter("E.123"));
+        Assert.IsType<E123PhoneNumberFormatter>(CountryInfo.GetFormatter("E.123"));
 
     [Fact]
     public void GetFormatter_E164_Returns_E164PhoneNumberFormatter() =>
-        Assert.IsType<E164PhoneNumberFormatter>(TestHelper.CreateCountryInfo().GetFormatter("E.164"));
+        Assert.IsType<E164PhoneNumberFormatter>(CountryInfo.GetFormatter("E.164"));
 
     [Fact]
     public void GetFormatter_N_Returns_NationalPhoneNumberFormatter() =>
-        Assert.IsType<NationalPhoneNumberFormatter>(TestHelper.CreateCountryInfo().GetFormatter("N"));
+        Assert.IsType<NationalPhoneNumberFormatter>(CountryInfo.GetFormatter("N"));
+
+    [Fact]
+    public void GetFormatter_RFC3966_Returns_E164PhoneNumberFormatter() =>
+        Assert.IsType<Rfc3966PhoneNumberFormatter>(CountryInfo.GetFormatter("RFC3966"));
 
     [Fact]
     public void GetFormatter_Throws_For_Invalid_Format() =>
-        Assert.Throws<FormatException>(() => TestHelper.CreateCountryInfo().GetFormatter("X"));
+        Assert.Throws<FormatException>(() => CountryInfo.GetFormatter("X"));
 
     [Theory]
     [InlineData(default(string))]

--- a/test/PhoneNumbers.Tests/PhoneNumberTests.cs
+++ b/test/PhoneNumbers.Tests/PhoneNumberTests.cs
@@ -68,7 +68,7 @@ public class PhoneNumberTests
         var phoneNumber = PhoneNumber.Parse("+441142726444");
 
         Assert.Equal(
-            phoneNumber.Country.GetFormatter(PhoneNumberFormatter.DefaultFormat).Format(phoneNumber),
+            CountryInfo.GetFormatter(PhoneNumberFormatter.DefaultFormat).Format(phoneNumber),
             phoneNumber.ToString());
     }
 


### PR DESCRIPTION
…jects

.NET compiler platform (Roslyn) analyzers inspect your C# or Visual Basic code for code quality and style issues. Starting in .NET 5, these analyzers are included with the .NET SDK and you don't need to install them separately. If your project targets .NET 5 or later, code analysis is enabled by default.

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?tabs=net-7