### PR TITLE
Ignore the .mono folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ bld/
 # Visual Studio Code cache/options directory
 .vscode/*
 !.vscode/settings.json
+.mono/*
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
This is added by the C# DevKit VS Code extension