### PR TITLE
Use List<T> with the native Find and Exists methods

### DIFF
--- a/src/PhoneNumbers/Parsers/CountryNumber.cs
+++ b/src/PhoneNumbers/Parsers/CountryNumber.cs
@@ -7,6 +7,6 @@ internal sealed record CountryNumber(
     string? GeographicArea,
     PhoneNumberHint Hint,
     PhoneNumberKind Kind,
-    IReadOnlyList<NumberRange>? NationalDestinationCodeRanges,
-    IReadOnlyList<NumberRange> SubscriberNumberRanges
+    List<NumberRange>? NationalDestinationCodeRanges,
+    List<NumberRange> SubscriberNumberRanges
 );

--- a/src/PhoneNumbers/Parsers/DefaultPhoneNumberParser.cs
+++ b/src/PhoneNumbers/Parsers/DefaultPhoneNumberParser.cs
@@ -15,14 +15,14 @@ internal class DefaultPhoneNumberParser : PhoneNumberParser
     /// <param name="countryInfo">The <see cref="CountryInfo"/> of the country for the parser.</param>
     /// <param name="countryNumbers">The <see cref="CountryNumber"/>s for the country.</param>
     /// <remarks>The constructor is internal for unit tests only.</remarks>
-    internal DefaultPhoneNumberParser(CountryInfo countryInfo, IReadOnlyList<CountryNumber> countryNumbers)
+    internal DefaultPhoneNumberParser(CountryInfo countryInfo, List<CountryNumber> countryNumbers)
         : base(countryInfo)
         => CountryNumbers = countryNumbers ?? throw new ArgumentNullException(nameof(countryNumbers));
 
     /// <summary>
     /// Gets the <see cref="CountryNumber"/>s for the country.
     /// </summary>
-    protected IReadOnlyList<CountryNumber> CountryNumbers { get; }
+    protected List<CountryNumber> CountryNumbers { get; }
 
     /// <summary>
     /// Creates an instance of the <see cref="DefaultPhoneNumberParser"/> class.
@@ -50,22 +50,20 @@ internal class DefaultPhoneNumberParser : PhoneNumberParser
                 var ndc = len > 0 ? nsnValue[0..len] : null;
                 var sn = ndc is not null ? nsnValue[len..] : nsnValue;
 
-                var countryNumber = CountryNumbers
-                    .FirstOrDefault(x =>
-                        (ndc is null || x.NationalDestinationCodeRanges?.Any(x => x.Contains(ndc)) == true) &&
-                        x.SubscriberNumberRanges.Any(x => x.Contains(sn)));
-
-                if (countryNumber is not null)
+                foreach (var countryNumber in CountryNumbers)
                 {
-                    return (ndc, sn, countryNumber);
+                    if ((ndc is null || countryNumber.NationalDestinationCodeRanges?.Exists(r => r.Contains(ndc)) == true) &&
+                        countryNumber.SubscriberNumberRanges.Exists(r => r.Contains(sn)))
+                    {
+                        return (ndc, sn, countryNumber);
+                    }
                 }
             }
         }
         else
         {
             var sn = nsnValue;
-            var countryNumber = CountryNumbers
-                .FirstOrDefault(x => x.SubscriberNumberRanges.Any(x => x.Contains(nsnValue)));
+            var countryNumber = CountryNumbers.Find(cn => cn.SubscriberNumberRanges.Exists(r => r.Contains(sn)));
 
             return (null, sn, countryNumber);
         }

--- a/src/PhoneNumbers/Parsers/GBPhoneNumberParser.cs
+++ b/src/PhoneNumbers/Parsers/GBPhoneNumberParser.cs
@@ -12,7 +12,7 @@ internal sealed class GBPhoneNumberParser : DefaultPhoneNumberParser
 {
     private readonly List<CountryNumber> _fiveDigitGeoNdcs;
 
-    private GBPhoneNumberParser(IReadOnlyList<CountryNumber> countryNumbers)
+    private GBPhoneNumberParser(List<CountryNumber> countryNumbers)
         : base(CountryInfo.UnitedKingdom, countryNumbers) =>
         _fiveDigitGeoNdcs = [.. countryNumbers.Where(x => x.GeographicArea is not null && x.NationalDestinationCodeRanges![0].From.Length == 5)];
 
@@ -68,7 +68,7 @@ internal sealed class GBPhoneNumberParser : DefaultPhoneNumberParser
         var sn = nsnValue[ndcLength..];
 
         var countryNumber = CountryNumbers
-            .FirstOrDefault(x => x.Kind == phoneNumberKind &&
+            .Find(x => x.Kind == phoneNumberKind &&
                 x.NationalDestinationCodeRanges!.Any(x => x.Contains(ndc)) &&
                 x.SubscriberNumberRanges.Any(x => x.Contains(sn)));
 

--- a/src/PhoneNumbers/Parsers/ResourceUtility.cs
+++ b/src/PhoneNumbers/Parsers/ResourceUtility.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using System.Reflection;
 
 namespace PhoneNumbers.Parsers;
@@ -7,8 +6,8 @@ internal static class ResourceUtility
 {
     // The file format is as follows (spaces for readability, not present in the file):
     // Kind | NDC Range(s) | Geographic Area | SN Range(s) | Hint
-    internal static IReadOnlyList<CountryNumber> ReadCountryNumbers(string name) =>
-        ReadLines(name)
+    internal static List<CountryNumber> ReadCountryNumbers(string name) =>
+        [.. ReadLines(name)
             .Select(x => x.Split(Chars.Pipe))
             .Select(x =>
             {
@@ -21,9 +20,7 @@ internal static class ResourceUtility
                     ParseNumberKind(x[0][0]),
                     x[1].Length > 0 ? ParseNumberRanges(x[1]) : null,
                     ParseNumberRanges(x[3]));
-            })
-            .ToList()
-            .AsReadOnly();
+            })];
 
     private static PhoneNumberHint ParseNumberHint(char value) =>
         value switch
@@ -48,12 +45,10 @@ internal static class ResourceUtility
             _ => throw new NotSupportedException(value.ToString()),
         };
 
-    private static ReadOnlyCollection<NumberRange> ParseNumberRanges(string value) =>
-        value
+    private static List<NumberRange> ParseNumberRanges(string value) =>
+        [.. value
             .Split(Chars.Comma)
-            .Select(NumberRange.Create)
-            .ToList()
-            .AsReadOnly();
+            .Select(NumberRange.Create)];
 
     private static IEnumerable<string> ReadLines(string name)
     {


### PR DESCRIPTION
This will out perform the Linq based approach since it's using the list index internally instead of IEnumerable.

Also where we are still using Linq methods, they will avoid the allocation of using IEnumerable via a collection interface.

This does come at the cost of some intent and readability however it's all internal code to the library.