### PR TITLE
Ignore empty lines in resource file parsing

### DIFF
--- a/src/PhoneNumbers/Parsers/ResourceUtility.cs
+++ b/src/PhoneNumbers/Parsers/ResourceUtility.cs
@@ -64,6 +64,11 @@ internal static class ResourceUtility
 
         while ((line = reader.ReadLine()) is not null)
         {
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
             if (line[0] != Chars.Hash)
             {
                 yield return line;


### PR DESCRIPTION
Skip empty lines while reading from the resource file.